### PR TITLE
ci: change jekyll deploy action

### DIFF
--- a/.github/workflows/build-jekyll.yml
+++ b/.github/workflows/build-jekyll.yml
@@ -19,8 +19,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
 
-      - uses: helaili/jekyll-action@2.0.3
-        env:
-          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+      - uses: jeffreytse/jekyll-deploy-action@v0.1.0
         with:
-          jekyll_src: './'
+          provider: 'github'
+          token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Hi @SubhadityaMukherjee 

The previous workflow action has some problems, now change to another one for better CI. After merging this, you also need to do the belows:

* Create a [Personal Token](https://github.com/settings/tokens) with repos permissions for CI.
* Go to your repository’s Settings and then the Secrets tab.
* Create a token named `GH_TOKEN` (important). Give it a value using the value copied above.